### PR TITLE
Fix build error under MacOS

### DIFF
--- a/include/MainBus.h
+++ b/include/MainBus.h
@@ -23,6 +23,13 @@ namespace sn
         JOY1 = 0x4016,
         JOY2 = 0x4017,
     };
+    struct IORegistersHasher
+    {
+        std::size_t operator()(sn::IORegisters const & reg) const noexcept
+        {
+            return std::hash<std::uint32_t>{}(reg);
+        }
+    };
 
     class MainBus
     {
@@ -39,8 +46,8 @@ namespace sn
             std::vector<Byte> m_extRAM;
             Mapper* m_mapper;
 
-            std::unordered_map<IORegisters, std::function<void(Byte)>> m_writeCallbacks;
-            std::unordered_map<IORegisters, std::function<Byte(void)>> m_readCallbacks;;
+            std::unordered_map<IORegisters, std::function<void(Byte)>, IORegistersHasher> m_writeCallbacks;
+            std::unordered_map<IORegisters, std::function<Byte(void)>, IORegistersHasher> m_readCallbacks;;
     };
 };
 


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

I tried to build SimpleNES under MacOS X but get errors. After applying this patch, I can build SimpleNES successfully.

Ref: https://en.cppreference.com/w/cpp/utility/hash

```
[1/6] Building CXX object CMakeFiles/SimpleNES.dir/src/CPU.cpp.o
FAILED: CMakeFiles/SimpleNES.dir/src/CPU.cpp.o 
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -D__FILENAME__=\"CPU.cpp\" -I/Users/jayson/Projects/myproj/SimpleNES/include -I/opt/homebrew/include -g -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -std=gnu++11 -MD -MT CMakeFiles/SimpleNES.dir/src/CPU.cpp.o -MF CMakeFiles/SimpleNES.dir/src/CPU.cpp.o.d -o CMakeFiles/SimpleNES.dir/src/CPU.cpp.o -c /Users/jayson/Projects/myproj/SimpleNES/src/CPU.cpp
In file included from /Users/jayson/Projects/myproj/SimpleNES/src/CPU.cpp:1:
In file included from /Users/jayson/Projects/myproj/SimpleNES/include/CPU.h:4:
In file included from /Users/jayson/Projects/myproj/SimpleNES/include/MainBus.h:3:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/vector:276:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/__bit_reference:15:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/algorithm:650:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/type_traits:1797:38: error: implicit instantiation of undefined template 'std::hash<sn::IORegisters>'
    : public integral_constant<bool, __is_empty(_Tp)> {};
                                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/unordered_map:451:18: note: in instantiation of template class 'std::is_empty<std::hash<sn::IORegisters>>' requested here
          bool = is_empty<_Hash>::value && !__libcpp_is_final<_Hash>::value>
                 ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/unordered_map:934:13: note: in instantiation of default argument for '__unordered_map_hasher<sn::IORegisters, std::__hash_value_type<sn::IORegisters, std::function<void (unsigned char)>>, std::hash<sn::IORegisters>, std::equal_to<sn::IORegisters>>' required here
    typedef __unordered_map_hasher<key_type, __value_type, hasher, key_equal> __hasher;
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jayson/Projects/myproj/SimpleNES/include/MainBus.h:42:72: note: in instantiation of template class 'std::unordered_map<sn::IORegisters, std::function<void (unsigned char)>>' requested here
            std::unordered_map<IORegisters, std::function<void(Byte)>> m_writeCallbacks;
                                                                       ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk/usr/include/c++/v1/type_traits:431:50: note: template is declared here
template <class _Tp> struct _LIBCPP_TEMPLATE_VIS hash;
                                                 ^
1 error generated.
```