### PR TITLE
Fix paused/unpaused log message

### DIFF
--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -95,11 +95,11 @@ namespace sn
                     if (!pause)
                     {
                         m_cycleTimer = std::chrono::high_resolution_clock::now();
-                        LOG(Info) << "Paused." << std::endl;
+                        LOG(Info) << "Unpaused." << std::endl;
                     }
                     else
                     {
-                        LOG(Info) << "Unpaused." << std::endl;
+                        LOG(Info) << "Paused." << std::endl;
                     }
                 }
                 else if (pause && event.type == sf::Event::KeyReleased && event.key.code == sf::Keyboard::F3)


### PR DESCRIPTION
They were in wrong order, this PR swaps them.